### PR TITLE
Update Kafka bootstrap server configuration in application properties

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -17,3 +17,5 @@ mp.messaging.outgoing.validation-response.value.serializer=io.quarkus.kafka.clie
 mp.messaging.incoming.validation-request.connector=smallrye-kafka
 mp.messaging.incoming.validation-request.topic=validation-request
 mp.messaging.incoming.validation-request.value.deserializer=ch.hftm.validation.models.ValidationRequestDeserializer
+
+kafka.bootstrap.servers=localhost:9092

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -22,3 +22,5 @@ mp.messaging.outgoing.validation-response.value.serializer=io.quarkus.kafka.clie
 mp.messaging.incoming.validation-request.connector=smallrye-kafka
 mp.messaging.incoming.validation-request.topic=validation-request
 mp.messaging.incoming.validation-request.value.deserializer=ch.hftm.validation.models.ValidationRequestDeserializer
+
+kafka.bootstrap.servers=redpanda-broker:9092


### PR DESCRIPTION
This pull request includes changes to the configuration files for the development and production environments. The most important changes involve adding the `kafka.bootstrap.servers` property to both files.

Configuration updates:

* [`src/main/resources/application-dev.properties`](diffhunk://#diff-cbee934a0dc2d724591feb74d9e4200e997b60b1f2b2a41b51336a0c83ab42b9R20-R21): Added `kafka.bootstrap.servers=localhost:9092` to configure the Kafka bootstrap servers for the development environment.
* [`src/main/resources/application-prod.properties`](diffhunk://#diff-53e0fee6660a4a2a0f74370f5a08f37733746fd612eca8c9df7ebd0dfdb613efR25-R26): Added `kafka.bootstrap.servers=redpanda-broker:9092` to configure the Kafka bootstrap servers for the production environment.